### PR TITLE
Configured Rspec, SimpleCov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .bundle/
 log/*.log
 pkg/
+coverage/
+*.swp

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,7 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
-require "rake/testtask"
+require "rspec/core/rake_task"
 
-task :default => :test
+RSpec::Core::RakeTask.new('spec')
 
-Rake::TestTask.new do |t|
-  t.libs << "lib"
-  t.libs << "test"
-  t.test_files = FileList["test/**/*_test.rb"]
-  t.verbose = true
-end
+task :default => :spec

--- a/sidekiq-priority.gemspec
+++ b/sidekiq-priority.gemspec
@@ -12,5 +12,9 @@ Gem::Specification.new do |s|
   s.version       = Sidekiq::Priority::VERSION
   s.license       = 'MIT'
 
-  s.add_dependency 'sidekiq', '>= 2.1.0'  
+  s.add_development_dependency "rspec"
+  s.add_development_dependency "simplecov"
+  s.add_development_dependency "simplecov-rcov"
+
+  s.add_dependency 'sidekiq', '>= 2.1.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,12 @@
 require 'rspec/autorun'
+require 'simplecov'
+
+SimpleCov.start do
+  add_filter "vendor"
+  add_filter "spec"
+  add_filter "version"
+end
+
 require 'sidekiq-priority'
 
 RSpec.configure do |config|
@@ -15,5 +23,4 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = "random"
-
 end


### PR DESCRIPTION
This will allow you to run your rspec tests (presently the only tests in the repo) using `rake` or `rake spec`. Further, you can see coverage information in coverage/index.html
