### PR TITLE
Using the default priority queue rather than creating an invalid one

### DIFF
--- a/lib/sidekiq/priority.rb
+++ b/lib/sidekiq/priority.rb
@@ -18,7 +18,7 @@ module Sidekiq
     end
 
     def self.queue_with_priority(queue, priority)
-      priority.nil? ? queue : "#{queue}_#{priority}"
+      priority && self.priorities.indlude?(priority) ? "#{queue}_#{priority}" : queue
     end
   end
 end

--- a/lib/sidekiq/priority.rb
+++ b/lib/sidekiq/priority.rb
@@ -18,7 +18,7 @@ module Sidekiq
     end
 
     def self.queue_with_priority(queue, priority)
-      priority && self.priorities.indlude?(priority) ? "#{queue}_#{priority}" : queue
+      priority && self.priorities.include?(priority) ? "#{queue}_#{priority}" : queue
     end
   end
 end

--- a/spec/sidekiq/worker_ext_spec.rb
+++ b/spec/sidekiq/worker_ext_spec.rb
@@ -22,5 +22,26 @@ describe Sidekiq::Worker do
         'queue' => 'foo_high'
       }
     end
+
+    it 'sends an item to the default queue if priority is nil' do
+      TestWorker.stub(:client_push) { |item| item }
+      item = TestWorker.perform_with_priority(:invalid_priority, 1, 2)
+      item.should == {
+          'class' => TestWorker,
+          'args' => [1, 2],
+          'queue' => :foo
+      }
+    end
+
+    it 'sends an item to the default queue if a random priority is given' do
+      TestWorker.stub(:client_push) { |item| item }
+      item = TestWorker.perform_with_priority(:random_priority, 1, 2)
+      item.should == {
+          'class' => TestWorker,
+          'args' => [1, 2],
+          'queue' => :foo
+      }
+    end
+
   end
 end


### PR DESCRIPTION
Modifying priority queue creation to place a job with a priority that is not found in Sidekiq::Priority.priorities in the default queue, rather than creating a new invalid one. This prevents a possible user error from placing jobs into a queue that is not being processed, placing them instead into the default queue.
